### PR TITLE
Improve expectException, assertion and fixtures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,11 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4
 
 before_script:
   - travis_retry composer self-update
-  - travis_retry composer install --no-interaction --prefer-source --dev
+  - travis_retry composer install --no-interaction --prefer-source
 
 script:
   - vendor/bin/phpunit --coverage-clover=coverage.xml

--- a/tests/Client/DeletePaymentTest.php
+++ b/tests/Client/DeletePaymentTest.php
@@ -49,7 +49,7 @@ class DeletePaymentTest extends TestCase
      */
     public function testFail()
     {
-        self::expectException(ClientException::class);
+        $this->expectException(ClientException::class);
 
         $client = new Client(['handler' => $this->failSidMockHandler]);
         $client = new SofortPayClient($client, new APIKey('943f288f-1c48-43b2-a082-efd1ec8bdc9e'));
@@ -60,7 +60,7 @@ class DeletePaymentTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Client/GetPaymentTest.php
+++ b/tests/Client/GetPaymentTest.php
@@ -42,7 +42,7 @@ class GetPaymentTest extends TestCase
 
         $response = $client->getPayment(Uuid::uuid4());
 
-        self::assertEquals('6d4cb746-ca71-442f-802a-0bdb7c0b2be1', $response->uuid);
+        $this->assertEquals('6d4cb746-ca71-442f-802a-0bdb7c0b2be1', $response->uuid);
     }
 
     /**
@@ -53,7 +53,7 @@ class GetPaymentTest extends TestCase
      */
     public function testFail()
     {
-        self::expectException(ClientException::class);
+        $this->expectException(ClientException::class);
 
         $client = new Client(['handler' => $this->failSidMockHandler]);
         $client = new SofortPayClient($client, new APIKey('943f288f-1c48-43b2-a082-efd1ec8bdc9e'));
@@ -64,7 +64,7 @@ class GetPaymentTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Client/InitializePaymentTest.php
+++ b/tests/Client/InitializePaymentTest.php
@@ -49,8 +49,8 @@ class InitializePaymentTest extends TestCase
 
         $response = $client->initializePayment($request);
 
-        self::assertEquals('6d4cb746-ca71-442f-802a-0bdb7c0b2be1', $response->uuid);
-        self::assertEquals('https://wizard.sofort-pay.com/wizard/c6e48a82-a524-403b-8760-b6d146519efa', $response->get('Payment-Form'));
+        $this->assertEquals('6d4cb746-ca71-442f-802a-0bdb7c0b2be1', $response->uuid);
+        $this->assertEquals('https://wizard.sofort-pay.com/wizard/c6e48a82-a524-403b-8760-b6d146519efa', $response->get('Payment-Form'));
     }
 
     /**
@@ -61,7 +61,7 @@ class InitializePaymentTest extends TestCase
      */
     public function testFail()
     {
-        self::expectException(ClientException::class);
+        $this->expectException(ClientException::class);
 
         $client = new Client(['handler' => $this->failSidMockHandler]);
         $client = new SofortPayClient($client, new APIKey('943f288f-1c48-43b2-a082-efd1ec8bdc9e'));
@@ -77,7 +77,7 @@ class InitializePaymentTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Factory/ResponseFactoryTest.php
+++ b/tests/Factory/ResponseFactoryTest.php
@@ -104,7 +104,7 @@ class ResponseFactoryTest extends TestCase
         $this->assertEquals('https://example.com/abort', $result->get('abort_url'));
         $this->assertEquals('default', $result->get('payform_code'));
         $this->assertEquals('6d4cb746-ca71-442f-802a-0bdb7c0b2be1', $result->get('uuid'));
-        $this->assertEquals(false, $result->get('testmode'));
+        $this->assertFalse($result->get('testmode'));
         $this->assertEquals('X-Paycode-Resource', $result->get('Paycode-Resource'));
         $this->assertEquals(100, $result->get('RateLimit-Limit'));
         $this->assertEquals(99, $result->get('RateLimit-Remaining'));

--- a/tests/Request/InitializePaymentRequestTest.php
+++ b/tests/Request/InitializePaymentRequestTest.php
@@ -31,7 +31,7 @@ class InitializePaymentRequestTest extends TestCase
             $parser->parse('1000000.51', 'EUR')
         );
 
-        self::assertEquals(
+        $this->assertEquals(
             [
                 'purpose' => 'Order ID: e45dcd16-030e-4e33-94e0-e34a097a7428',
                 'currency_id' => 'EUR',
@@ -50,7 +50,7 @@ class InitializePaymentRequestTest extends TestCase
             ->setLanguage(new Language('en'))
         ;
 
-        self::assertEquals(
+        $this->assertEquals(
             [
                 'purpose' => 'Order ID: e45dcd16-030e-4e33-94e0-e34a097a7428',
                 'currency_id' => 'EUR',
@@ -66,6 +66,6 @@ class InitializePaymentRequestTest extends TestCase
             $request->getPayload()
         );
 
-        self::assertInstanceOf(InitializePaymentRequest::class, $res);
+        $this->assertInstanceOf(InitializePaymentRequest::class, $res);
     }
 }

--- a/tests/Signature/SignatureVerifierTest.php
+++ b/tests/Signature/SignatureVerifierTest.php
@@ -24,7 +24,7 @@ class SignatureVerifierTest extends TestCase
         $xPayloadSignature = 'v1=b95ac0a6fbb0f868eb2e66fafbc79bc1e31995b0773b78de515c9c1dc5d7038a';
         $json = file_get_contents(__DIR__ . '/DataFixtures/success-signature-verify.json');
 
-        self::assertTrue($verifier->verify($xPayloadSignature, $json));
+        $this->assertTrue($verifier->verify($xPayloadSignature, $json));
     }
 
     /**
@@ -38,6 +38,6 @@ class SignatureVerifierTest extends TestCase
         $xPayloadSignature = 'v1=b95ac0a6fbb0f868eb2e66fafbc79bc1e31995b0773b78de515c9c1dc5d7038a';
         $json = file_get_contents(__DIR__ . '/DataFixtures/fail-signature-verify.json');
 
-        self::assertFalse($verifier->verify($xPayloadSignature, $json));
+        $this->assertFalse($verifier->verify($xPayloadSignature, $json));
     }
 }

--- a/tests/ValueObject/APIKeyTest.php
+++ b/tests/ValueObject/APIKeyTest.php
@@ -21,7 +21,7 @@ class APIKeyTest extends TestCase
         $value = '51930bcb-0028-4320-8932-13731f21fc28';
         $APIKey = new APIKey($value);
 
-        self::assertEquals($value, (string) $APIKey);
+        $this->assertEquals($value, (string) $APIKey);
     }
 
     /**
@@ -29,8 +29,8 @@ class APIKeyTest extends TestCase
      */
     public function testInvalidValue()
     {
-        self::expectException(InvalidAPIKeyException::class);
-        self::expectExceptionMessage('API key should be valid UUID.');
+        $this->expectException(InvalidAPIKeyException::class);
+        $this->expectExceptionMessage('API key should be valid UUID.');
 
         new APIKey('test');
     }

--- a/tests/ValueObject/LanguageTest.php
+++ b/tests/ValueObject/LanguageTest.php
@@ -24,7 +24,7 @@ class LanguageTest extends TestCase
     {
         $currency = new Language($value);
 
-        self::assertEquals($value, (string) $currency);
+        $this->assertEquals($value, (string) $currency);
     }
 
     /**
@@ -45,8 +45,8 @@ class LanguageTest extends TestCase
      */
     public function testInvalidValue()
     {
-        self::expectException(InvalidLanguageException::class);
-        self::expectExceptionMessage('Not accepted language by Sofort Pay.');
+        $this->expectException(InvalidLanguageException::class);
+        $this->expectExceptionMessage('Not accepted language by Sofort Pay.');
 
         new Language('test');
     }

--- a/tests/ValueObject/SharedSecretTest.php
+++ b/tests/ValueObject/SharedSecretTest.php
@@ -21,7 +21,7 @@ class SharedSecretTest extends TestCase
         $value = 'test123';
         $sharedSecret = new SharedSecret($value);
 
-        self::assertEquals($value, (string) $sharedSecret);
+        $this->assertEquals($value, (string) $sharedSecret);
     }
 
     /**
@@ -29,8 +29,8 @@ class SharedSecretTest extends TestCase
      */
     public function testEmptyValue()
     {
-        self::expectException(InvalidSharedSecretException::class);
-        self::expectExceptionMessage('WebHook shared secret should not be blank.');
+        $this->expectException(InvalidSharedSecretException::class);
+        $this->expectExceptionMessage('WebHook shared secret should not be blank.');
 
         new SharedSecret(' ');
     }

--- a/tests/ValueObject/TransactionIdTest.php
+++ b/tests/ValueObject/TransactionIdTest.php
@@ -21,7 +21,7 @@ class TransactionIdTest extends TestCase
         $value = 'test123';
         $transactionId = new TransactionID($value);
 
-        self::assertEquals($value, (string) $transactionId);
+        $this->assertEquals($value, (string) $transactionId);
     }
 
     /**
@@ -29,8 +29,8 @@ class TransactionIdTest extends TestCase
      */
     public function testEmptyValue()
     {
-        self::expectException(InvalidTransactionIDException::class);
-        self::expectExceptionMessage('Transaction ID should not be blank.');
+        $this->expectException(InvalidTransactionIDException::class);
+        $this->expectExceptionMessage('Transaction ID should not be blank.');
 
         new TransactionID(' ');
     }

--- a/tests/ValueObject/UrlTest.php
+++ b/tests/ValueObject/UrlTest.php
@@ -18,8 +18,8 @@ class UrlTest extends TestCase
      */
     public function testEmpty()
     {
-        self::expectException(InvalidUrlException::class);
-        self::expectExceptionMessage('"" is not a valid url.');
+        $this->expectException(InvalidUrlException::class);
+        $this->expectExceptionMessage('"" is not a valid url.');
 
         new Url('');
     }
@@ -29,8 +29,8 @@ class UrlTest extends TestCase
      */
     public function testInvalidMaxLength()
     {
-        self::expectException(InvalidUrlException::class);
-        self::expectExceptionMessage('URL is too long. It should have 2048 characters or less.');
+        $this->expectException(InvalidUrlException::class);
+        $this->expectExceptionMessage('URL is too long. It should have 2048 characters or less.');
 
         new Url(str_repeat('a', 2500));
     }
@@ -43,7 +43,7 @@ class UrlTest extends TestCase
         $url = 'https://api.com';
         $baseApiUrl = new Url($url);
 
-        self::assertEquals($url, (string) $baseApiUrl);
+        $this->assertEquals($url, (string) $baseApiUrl);
     }
 
     /**
@@ -51,8 +51,8 @@ class UrlTest extends TestCase
      */
     public function testInvalidUrl()
     {
-        self::expectException(InvalidUrlException::class);
-        self::expectExceptionMessage('"localhost" is not a valid url.');
+        $this->expectException(InvalidUrlException::class);
+        $this->expectExceptionMessage('"localhost" is not a valid url.');
 
         new Url('localhost');
     }


### PR DESCRIPTION
# Changed log
- Add `php-7.4` verison during Travis CI build.
- Removing `--dev` option because this option is deprecated. The deprecated warning message is as follows:

```
You are using the deprecated option "dev". Dev packages are installed by default now.
```
- There're two ways PHPUnit assertion calls in this library project folder.
To be consistency, using the `$this` to replace all assertion calls because using `$this` times are greater than using `self::`.

- Using the `$this->exception` and `$this->expectExceptionMessage` method calls because it fixes the `Non static method 'expectException' should not be called` and `Non static method 'expectExceptionMessage' should not be called` issues.
- Using the `assertFalse` assertion to assert expected value is `false`.