### PR TITLE
Improve equals assertion

### DIFF
--- a/tests/Client/GetPaymentTest.php
+++ b/tests/Client/GetPaymentTest.php
@@ -42,7 +42,7 @@ class GetPaymentTest extends TestCase
 
         $response = $client->getPayment(Uuid::uuid4());
 
-        $this->assertEquals('6d4cb746-ca71-442f-802a-0bdb7c0b2be1', $response->uuid);
+        $this->assertSame('6d4cb746-ca71-442f-802a-0bdb7c0b2be1', $response->uuid);
     }
 
     /**

--- a/tests/Client/InitializePaymentTest.php
+++ b/tests/Client/InitializePaymentTest.php
@@ -49,8 +49,8 @@ class InitializePaymentTest extends TestCase
 
         $response = $client->initializePayment($request);
 
-        $this->assertEquals('6d4cb746-ca71-442f-802a-0bdb7c0b2be1', $response->uuid);
-        $this->assertEquals('https://wizard.sofort-pay.com/wizard/c6e48a82-a524-403b-8760-b6d146519efa', $response->get('Payment-Form'));
+        $this->assertSame('6d4cb746-ca71-442f-802a-0bdb7c0b2be1', $response->uuid);
+        $this->assertSame('https://wizard.sofort-pay.com/wizard/c6e48a82-a524-403b-8760-b6d146519efa', $response->get('Payment-Form'));
     }
 
     /**

--- a/tests/Factory/ResponseFactoryTest.php
+++ b/tests/Factory/ResponseFactoryTest.php
@@ -33,19 +33,19 @@ class ResponseFactoryTest extends TestCase
 
         $result = ResponseFactory::fromPsrResponse(new Response(200, $headers, $body));
 
-        $this->assertEquals(10.5, $result->get('amount'));
-        $this->assertEquals('EUR', $result->get('currency_id'));
-        $this->assertEquals('Order ID: 1234', $result->get('purpose'));
-        $this->assertEquals('de', $result->get('language'));
-        $this->assertEquals('https://example.com/success', $result->get('success_url'));
-        $this->assertEquals('https://example.com/webhook', $result->get('webhook_url'));
-        $this->assertEquals('https://example.com/abort', $result->get('abort_url'));
-        $this->assertEquals('default', $result->get('payform_code'));
-        $this->assertEquals('6d4cb746-ca71-442f-802a-0bdb7c0b2be1', $result->get('uuid'));
-        $this->assertEquals('X-Payment-Form', $result->get('Payment-Form'));
-        $this->assertEquals('Location', $result->get('Location'));
-        $this->assertEquals(100, $result->get('RateLimit-Limit'));
-        $this->assertEquals(99, $result->get('RateLimit-Remaining'));
+        $this->assertSame(10.5, $result->get('amount'));
+        $this->assertSame('EUR', $result->get('currency_id'));
+        $this->assertSame('Order ID: 1234', $result->get('purpose'));
+        $this->assertSame('de', $result->get('language'));
+        $this->assertSame('https://example.com/success', $result->get('success_url'));
+        $this->assertSame('https://example.com/webhook', $result->get('webhook_url'));
+        $this->assertSame('https://example.com/abort', $result->get('abort_url'));
+        $this->assertSame('default', $result->get('payform_code'));
+        $this->assertSame('6d4cb746-ca71-442f-802a-0bdb7c0b2be1', $result->get('uuid'));
+        $this->assertSame('X-Payment-Form', $result->get('Payment-Form'));
+        $this->assertSame('Location', $result->get('Location'));
+        $this->assertSame(100, $result->get('RateLimit-Limit'));
+        $this->assertSame(99, $result->get('RateLimit-Remaining'));
         $this->assertEquals(
             [
                 'key1' => 'value1',
@@ -95,19 +95,19 @@ class ResponseFactoryTest extends TestCase
 
         $result = ResponseFactory::fromPsrResponse(new Response(200, $headers, $body));
 
-        $this->assertEquals(10.5, $result->get('amount'));
-        $this->assertEquals('EUR', $result->get('currency_id'));
-        $this->assertEquals('Order ID: 1234', $result->get('purpose'));
-        $this->assertEquals('de', $result->get('language'));
-        $this->assertEquals('https://example.com/success', $result->get('success_url'));
-        $this->assertEquals('https://example.com/webhook', $result->get('webhook_url'));
-        $this->assertEquals('https://example.com/abort', $result->get('abort_url'));
-        $this->assertEquals('default', $result->get('payform_code'));
-        $this->assertEquals('6d4cb746-ca71-442f-802a-0bdb7c0b2be1', $result->get('uuid'));
+        $this->assertSame(10.5, $result->get('amount'));
+        $this->assertSame('EUR', $result->get('currency_id'));
+        $this->assertSame('Order ID: 1234', $result->get('purpose'));
+        $this->assertSame('de', $result->get('language'));
+        $this->assertSame('https://example.com/success', $result->get('success_url'));
+        $this->assertSame('https://example.com/webhook', $result->get('webhook_url'));
+        $this->assertSame('https://example.com/abort', $result->get('abort_url'));
+        $this->assertSame('default', $result->get('payform_code'));
+        $this->assertSame('6d4cb746-ca71-442f-802a-0bdb7c0b2be1', $result->get('uuid'));
         $this->assertFalse($result->get('testmode'));
-        $this->assertEquals('X-Paycode-Resource', $result->get('Paycode-Resource'));
-        $this->assertEquals(100, $result->get('RateLimit-Limit'));
-        $this->assertEquals(99, $result->get('RateLimit-Remaining'));
+        $this->assertSame('X-Paycode-Resource', $result->get('Paycode-Resource'));
+        $this->assertSame(100, $result->get('RateLimit-Limit'));
+        $this->assertSame(99, $result->get('RateLimit-Remaining'));
         $this->assertEquals(
             [
                 'key1' => 'value1',

--- a/tests/Response/ResponseTest.php
+++ b/tests/Response/ResponseTest.php
@@ -177,7 +177,7 @@ class ResponseTest extends TestCase
         $userId = 111;
         $response = new Response(['userId' => $userId]);
 
-        $this->assertEquals($userId, $response->userId);
+        $this->assertSame($userId, $response->userId);
     }
 
     public function testGetNotExistsPropertyValue()
@@ -199,9 +199,9 @@ class ResponseTest extends TestCase
             ],
         ]);
 
-        $this->assertEquals($street, $response->get('address.street'));
-        $this->assertEquals($userId, $response->userId);
-        $this->assertEquals($userId, $response->get('userId'));
+        $this->assertSame($street, $response->get('address.street'));
+        $this->assertSame($userId, $response->userId);
+        $this->assertSame($userId, $response->get('userId'));
         $this->assertEquals(['street' => $street], $response->address);
     }
 }

--- a/tests/ValueObject/APIKeyTest.php
+++ b/tests/ValueObject/APIKeyTest.php
@@ -21,7 +21,7 @@ class APIKeyTest extends TestCase
         $value = '51930bcb-0028-4320-8932-13731f21fc28';
         $APIKey = new APIKey($value);
 
-        $this->assertEquals($value, (string) $APIKey);
+        $this->assertSame($value, (string) $APIKey);
     }
 
     /**

--- a/tests/ValueObject/LanguageTest.php
+++ b/tests/ValueObject/LanguageTest.php
@@ -24,7 +24,7 @@ class LanguageTest extends TestCase
     {
         $currency = new Language($value);
 
-        $this->assertEquals($value, (string) $currency);
+        $this->assertSame($value, (string) $currency);
     }
 
     /**

--- a/tests/ValueObject/SharedSecretTest.php
+++ b/tests/ValueObject/SharedSecretTest.php
@@ -21,7 +21,7 @@ class SharedSecretTest extends TestCase
         $value = 'test123';
         $sharedSecret = new SharedSecret($value);
 
-        $this->assertEquals($value, (string) $sharedSecret);
+        $this->assertSame($value, (string) $sharedSecret);
     }
 
     /**

--- a/tests/ValueObject/TransactionIdTest.php
+++ b/tests/ValueObject/TransactionIdTest.php
@@ -21,7 +21,7 @@ class TransactionIdTest extends TestCase
         $value = 'test123';
         $transactionId = new TransactionID($value);
 
-        $this->assertEquals($value, (string) $transactionId);
+        $this->assertSame($value, (string) $transactionId);
     }
 
     /**

--- a/tests/ValueObject/UrlTest.php
+++ b/tests/ValueObject/UrlTest.php
@@ -43,7 +43,7 @@ class UrlTest extends TestCase
         $url = 'https://api.com';
         $baseApiUrl = new Url($url);
 
-        $this->assertEquals($url, (string) $baseApiUrl);
+        $this->assertSame($url, (string) $baseApiUrl);
     }
 
     /**


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to replace `assertEquals` make assertion equals strict.